### PR TITLE
chore: clippy + fmt cleanup so CLAUDE.md quality gate passes clean

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Clean
       run: cargo clean
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+    - name: Clippy (deny warnings)
+      run: cargo clippy --all-features --all-targets -- -D warnings
     - name: Build cli
       run: cargo build --features cli --verbose
     - name: Run tests

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,17 +1,19 @@
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use fatigue::interpolate::{InterpolationStrategyEnum, Linear, NDInterpolation};
-use fatigue::timeseries::Point;
 use fatigue::rainflow::rainflow;
+use fatigue::timeseries::Point;
 use rand::distributions::{Distribution, Uniform}; // 0.6.5
 
 fn setup_large_dataset(interpolator: &mut NDInterpolation) {
     for x in 1..=100 {
         // Simulating a 3D dataset with a straightforward relationship
         let coordinates = vec![x as f64, x as f64 * 2.0, x as f64 * 3.0]; // Example linear relationship in 3D
-        let point = Point { coordinates, file: None }; // Assuming Point::coordinates is Vec<f64>
+        let point = Point {
+            coordinates,
+            file: None,
+        }; // Assuming Point::coordinates is Vec<f64>
         let value = x as f64 * 2.0; // Value is a function of x for simplicity
-        
+
         interpolator.add_point(point, value);
     }
 }
@@ -31,7 +33,6 @@ fn setup_large_dataset_target() -> Vec<Vec<f64>> {
     targets
 }
 
-
 fn bench_linear_interpolation(c: &mut Criterion) {
     c.bench_function("linear interpolation large dataset", |b| {
         let strategy = InterpolationStrategyEnum::Linear(Linear);
@@ -40,14 +41,15 @@ fn bench_linear_interpolation(c: &mut Criterion) {
         let target_point = setup_large_dataset_target();
 
         b.iter(|| {
-            interpolator.interpolate(&black_box(target_point.clone())).unwrap();
+            interpolator
+                .interpolate(&black_box(target_point.clone()))
+                .unwrap();
         });
     });
 }
 
 fn bench_rainflow(c: &mut Criterion) {
     c.bench_function("Rainflow counting algorithm on large dataset", |b| {
-
         let step = Uniform::new(0.0, 50.0);
         let mut rng = rand::thread_rng();
         let choices: Vec<f64> = step.sample_iter(&mut rng).take(100000).collect();

--- a/src/app_logic.rs
+++ b/src/app_logic.rs
@@ -1,8 +1,8 @@
 //! A module for the main application logic for the fatigue assessment tool
 use crate::config::load_config;
 pub use crate::stress::read_stress_tensors_from_file;
-use std::path::PathBuf;
 use anyhow::Result;
+use std::path::PathBuf;
 
 pub fn run(config_path: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("Running with configuration: {}", config_path);
@@ -10,7 +10,7 @@ pub fn run(config_path: &str) -> Result<(), Box<dyn std::error::Error>> {
     let res = conf.timeseries.parse_input();
     for inter in conf.timeseries.interpolations.iter() {
         for point in inter.points.iter() {
-            if let Some(ref file_name) = point.file{
+            if let Some(ref file_name) = point.file {
                 let path = PathBuf::from(&inter.path).join(file_name); // Correctly constructs the path
                 let tensors = read_stress_tensors_from_file(&path)?; // Assuming the function accepts a `&Path`
                 println!("Stress tensors: {:?}", tensors);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
 //! A module for validating and managing configurations for a structural analysis application.
 
+use crate::material::Material;
+use crate::timeseries::TimeSeries;
+use anyhow::{anyhow, Result};
 use serde::Deserialize;
+use serde_yaml;
 use std::fs;
 use std::path::Path;
-use serde_yaml;
-use anyhow::{Result, anyhow};
-use crate::material::Material; 
-use crate::timeseries::TimeSeries;
 
 /// Represents the configuration for a structural analysis application.
 #[derive(Debug, Deserialize)]
@@ -26,7 +26,7 @@ impl Config {
         self.solution.validate()?;
         self.material.validate()?;
         self.safety_factor.validate()?;
-        self.timeseries.validate()?;           
+        self.timeseries.validate()?;
         self.validate_sensor_against_sensorfile()?;
         Ok(())
     }
@@ -34,9 +34,11 @@ impl Config {
     /// Validates that all sensors specified in the `TimeSeries` configuration
     /// exist within the sensor file.
     fn validate_sensor_against_sensorfile(&self) -> Result<()> {
-        let sen = self.timeseries.read_sensorfile()
+        let sen = self
+            .timeseries
+            .read_sensorfile()
             .map_err(|e| anyhow!("Failed to read sensor file: {}", e))?;
-        
+
         for interp in self.timeseries.interpolations.iter() {
             for sensor in interp.sensor.iter() {
                 if !sen.iter().any(|s| s.name == *sensor) {
@@ -48,7 +50,6 @@ impl Config {
         Ok(())
     }
 }
-
 
 /// Represents the solution configuration for a structural analysis session.
 ///
@@ -94,16 +95,25 @@ impl Solution {
     pub fn validate(&self) -> Result<()> {
         match self.run_type.as_str() {
             "FAT" | "NONE" => Ok(()),
-            _ => Err(anyhow!("run_type must be FAT or NONE, got {}", self.run_type)),
+            _ => Err(anyhow!(
+                "run_type must be FAT or NONE, got {}",
+                self.run_type
+            )),
         }?;
 
         match self.mode.as_str() {
             "STRESS" | "NONE" => Ok(()),
-            _ => Err(anyhow!("mode must be STRESS, STRAIN, or NONE, got {}", self.mode)),
+            _ => Err(anyhow!(
+                "mode must be STRESS, STRAIN, or NONE, got {}",
+                self.mode
+            )),
         }?;
         match self.output.as_str() {
             "JSON" => Ok(()),
-            _ => Err(anyhow!("output must be ANSYS or ASCII, got {}", self.output)),
+            _ => Err(anyhow!(
+                "output must be ANSYS or ASCII, got {}",
+                self.output
+            )),
         }?;
 
         self.stress_criteria.validate()?;
@@ -171,7 +181,10 @@ impl StressCriteria {
         };
         match self.method.as_str() {
             "VONMISES" | "MAXIMUM" | "SXXCRIT" | "NONE" => Ok(()),
-            _ => Err(anyhow!("method must be VONMISES, MAXIMUM, SXXCRIT, or NONE, got {}", self.method)),
+            _ => Err(anyhow!(
+                "method must be VONMISES, MAXIMUM, SXXCRIT, or NONE, got {}",
+                self.method
+            )),
         }?;
         Ok(())
     }
@@ -221,22 +234,31 @@ impl Mean {
     /// };
     /// assert!(invalid_mean_correction.validate().is_err());
     /// ```    
-    /// 
+    ///
     pub fn validate(&self) -> Result<()> {
         // Validate 'mean' field
         match self.mean.as_str() {
             "GOODMAN" | "LINEAR" | "BI-LINEAR" | "NONE" => Ok(()),
-            _ => Err(anyhow!("mean must be GOODMAN, LINEAR, BI-LINEAR, or NONE, got {}", self.mean)),
+            _ => Err(anyhow!(
+                "mean must be GOODMAN, LINEAR, BI-LINEAR, or NONE, got {}",
+                self.mean
+            )),
         }?;
 
         // Validate 'postfix' field
         match self.postfix.as_str() {
             "FIXEDMEAN" | "NONE" => Ok(()),
-            _ => Err(anyhow!("postfix must be FIXEDMEAN or NONE, got {}", self.postfix)),
+            _ => Err(anyhow!(
+                "postfix must be FIXEDMEAN or NONE, got {}",
+                self.postfix
+            )),
         }?;
 
         if !(0.0..=1.0).contains(&self.number.parse::<f64>().unwrap()) {
-            return Err(anyhow!("number must be between 0.0 and 1.0, got {}", self.number));
+            return Err(anyhow!(
+                "number must be between 0.0 and 1.0, got {}",
+                self.number
+            ));
         };
         Ok(())
     }
@@ -313,12 +335,18 @@ impl Damage {
     ///
     /// Returns `Ok(())` if both `error` and `dadm` are within the range [0.0, 1.0]. Otherwise,
     /// it returns a `ValidationError` detailing which field is out of the expected range.    
-    pub fn validate(&self) -> Result<()>{
+    pub fn validate(&self) -> Result<()> {
         if !(0.0..=1.0).contains(&self.error) {
-            return Err(anyhow!("error must be between 0.0 and 1.0, got {}", self.error));
+            return Err(anyhow!(
+                "error must be between 0.0 and 1.0, got {}",
+                self.error
+            ));
         }
         if !(0.0..=1.0).contains(&self.dadm) {
-            return Err(anyhow!("dadm must be between 0.0 and 1.0, got {}", self.dadm));
+            return Err(anyhow!(
+                "dadm must be between 0.0 and 1.0, got {}",
+                self.dadm
+            ));
         }
         Ok(())
     }
@@ -366,13 +394,22 @@ impl SafetyFactor {
     /// ```
     pub fn validate(&self) -> Result<()> {
         if !(1.0..=2.0).contains(&self.gmre) {
-            return Err(anyhow!("gmre must be between 1.0 and 2.0, got {}", self.gmre));
+            return Err(anyhow!(
+                "gmre must be between 1.0 and 2.0, got {}",
+                self.gmre
+            ));
         }
         if !(1.0..=2.0).contains(&self.gmrm) {
-            return Err(anyhow!("gmrm must be between 1.0 and 2.0, got {}", self.gmrm));
+            return Err(anyhow!(
+                "gmrm must be between 1.0 and 2.0, got {}",
+                self.gmrm
+            ));
         }
         if !(1.0..=2.0).contains(&self.gmfat) {
-            return Err(anyhow!("gmfat must be between 1.0 and 2.0, got {}", self.gmfat));
+            return Err(anyhow!(
+                "gmfat must be between 1.0 and 2.0, got {}",
+                self.gmfat
+            ));
         }
         Ok(())
     }
@@ -412,7 +449,11 @@ mod tests {
     fn test_load_config() {
         let config_path = "tests/config.yaml"; // Adjust the path as needed
         let config = load_config(config_path).expect("Failed to load config");
-        assert!(config.validate().is_ok(), "Expected Ok(()) but got Err with {:?}", config.validate());
+        assert!(
+            config.validate().is_ok(),
+            "Expected Ok(()) but got Err with {:?}",
+            config.validate()
+        );
         // Additional tests as needed
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,8 +83,9 @@ impl Solution {
     /// - `run_type` is either "FAT" or "NONE".
     /// - `mode` is either "STRESS" or "NONE".
     /// - `output` is "JSON", indicating the output format.
-    /// Additionally, it invokes validation on nested structs (`stress_criteria`, `mean`, `node`, `damage`)
-    /// to ensure their configurations are also valid.
+    ///
+    /// Additionally, it invokes validation on nested structs (`stress_criteria`,
+    /// `mean`, `node`, `damage`) to ensure their configurations are also valid.
     ///
     /// # Returns
     ///
@@ -415,12 +416,6 @@ impl SafetyFactor {
     }
 }
 
-/// Additional struct and impl blocks would follow the same pattern:
-/// - Briefly describe the purpose of the struct.
-/// - Document each public field if necessary.
-/// - For each method, describe what it does, its parameters, and its return value.
-/// - Use examples in the documentation where appropriate.
-
 /// Loads the configuration from a YAML file.
 ///
 /// # Arguments
@@ -434,7 +429,6 @@ impl SafetyFactor {
 /// # Errors
 ///
 /// This function will return an error if reading or parsing the configuration file fails.
-
 pub fn load_config<P: AsRef<Path>>(config_path: P) -> Result<Config, Box<dyn std::error::Error>> {
     let content = fs::read_to_string(config_path)?;
     let config: Config = serde_yaml::from_str(&content)?;

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 const TOLERANCE: f64 = 1e-5;
 
@@ -44,18 +44,25 @@ impl Hash for Point {
     }
 }
 
-
 // Define a trait for our interpolation strategies
 pub trait InterpolationStrategy {
     // Corrected to include only two parameters: points and target
-    fn interpolate(&self, points: &HashMap<Point, f64>, target: &Vec<Vec<f64>>) -> Result<Vec<f64>, String>;
+    fn interpolate(
+        &self,
+        points: &HashMap<Point, f64>,
+        target: &Vec<Vec<f64>>,
+    ) -> Result<Vec<f64>, String>;
 }
 
 // Implement nearest-neighbor interpolation
 pub struct NearestNeighbor;
 
 impl InterpolationStrategy for NearestNeighbor {
-    fn interpolate(&self, points: &HashMap<Point, f64>, target: &Vec<Vec<f64>>) -> Result<Vec<f64>, String> {
+    fn interpolate(
+        &self,
+        points: &HashMap<Point, f64>,
+        target: &Vec<Vec<f64>>,
+    ) -> Result<Vec<f64>, String> {
         if points.is_empty() {
             return Err("No points available for interpolation.".to_string());
         }
@@ -63,11 +70,15 @@ impl InterpolationStrategy for NearestNeighbor {
         // Convert HashMap into a Vec once to avoid repetitive hashing operations
         let points_vec: Vec<(&Point, &f64)> = points.iter().collect();
 
-        let results: Result<Vec<_>, _> = target.par_iter()
+        let results: Result<Vec<_>, _> = target
+            .par_iter()
             .map(|target_vec| {
-                points_vec.iter()
+                points_vec
+                    .iter()
                     .map(|(point, &value)| {
-                        let distance = point.coordinates.iter()
+                        let distance = point
+                            .coordinates
+                            .iter()
                             .zip(target_vec)
                             .map(|(a, b)| (a - b).powi(2))
                             .sum::<f64>()
@@ -75,7 +86,7 @@ impl InterpolationStrategy for NearestNeighbor {
                         (distance, value)
                     })
                     .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
-                    .map(|(_, value)| value)  // Dereference value to return the f64 directly
+                    .map(|(_, value)| value) // Dereference value to return the f64 directly
                     .ok_or_else(|| "Error finding nearest neighbor.".to_string())
             })
             .collect();
@@ -84,18 +95,22 @@ impl InterpolationStrategy for NearestNeighbor {
     }
 }
 
-
 // Implement linear interpolation
 pub struct Linear;
 
 impl InterpolationStrategy for Linear {
-    fn interpolate(&self, points: &HashMap<Point, f64>, target: &Vec<Vec<f64>>) -> Result<Vec<f64>, String> {
+    fn interpolate(
+        &self,
+        points: &HashMap<Point, f64>,
+        target: &Vec<Vec<f64>>,
+    ) -> Result<Vec<f64>, String> {
         if points.len() < 2 {
             return Err("Not enough points for interpolation".to_string());
         }
 
         // Convert points to a format suitable for SVD and regression
-        let points_vec: Vec<(Vec<f64>, f64)> = points.iter()
+        let points_vec: Vec<(Vec<f64>, f64)> = points
+            .iter()
             .map(|(point, &value)| (point.coordinates.clone(), value))
             .collect();
 
@@ -103,15 +118,20 @@ impl InterpolationStrategy for Linear {
             .map_err(|e| format!("Failed to perform linear regression: {}", e))?;
 
         // Use parallel iterator on targets for prediction
-        let predictions: Result<Vec<f64>, _> = target.par_iter()
+        let predictions: Result<Vec<f64>, _> = target
+            .par_iter()
             .map(|t| {
-                let predicted_value = coefficients[0] + t.iter().enumerate().map(|(i, coord)| {
-                    if i + 1 < coefficients.len() {
-                        coefficients[i + 1] * coord
-                    } else {
-                        0.0
-                    }
-                }).sum::<f64>();
+                let predicted_value = coefficients[0]
+                    + t.iter()
+                        .enumerate()
+                        .map(|(i, coord)| {
+                            if i + 1 < coefficients.len() {
+                                coefficients[i + 1] * coord
+                            } else {
+                                0.0
+                            }
+                        })
+                        .sum::<f64>();
                 Ok(predicted_value)
             })
             .collect();
@@ -126,7 +146,8 @@ fn multivariate_linear_regression_svd(points: &[(Vec<f64>, f64)]) -> Result<Vec<
     }
 
     // Parallel processing to prepare x_data and y_data
-    let (x_data, y_data): (Vec<_>, Vec<f64>) = points.par_iter()
+    let (x_data, y_data): (Vec<_>, Vec<f64>) = points
+        .par_iter()
         .map(|(features, target)| {
             let mut row = vec![1.0]; // Intercept term
             row.extend(features.iter().cloned());
@@ -147,10 +168,12 @@ fn multivariate_linear_regression_svd(points: &[(Vec<f64>, f64)]) -> Result<Vec<
     let svd = x.svd(true, true);
     match svd.solve(&y, 1e-12) {
         Ok(solution) => Ok(solution.iter().cloned().collect()),
-        Err(e) => Err(format!("Failed to solve the linear system using SVD: {}", e)),
+        Err(e) => Err(format!(
+            "Failed to solve the linear system using SVD: {}",
+            e
+        )),
     }
 }
-
 
 // Enum to encapsulate different strategies
 pub enum InterpolationStrategyEnum {
@@ -159,10 +182,16 @@ pub enum InterpolationStrategyEnum {
 }
 
 impl InterpolationStrategyEnum {
-    pub fn interpolate(&self, points: &HashMap<Point, f64>, target: &Vec<Vec<f64>>) -> Result<Vec<f64>, String> {
+    pub fn interpolate(
+        &self,
+        points: &HashMap<Point, f64>,
+        target: &Vec<Vec<f64>>,
+    ) -> Result<Vec<f64>, String> {
         match self {
             InterpolationStrategyEnum::Linear(strategy) => strategy.interpolate(&points, &target),
-            InterpolationStrategyEnum::NearestNeighbor(strategy) => strategy.interpolate(&points,&target),
+            InterpolationStrategyEnum::NearestNeighbor(strategy) => {
+                strategy.interpolate(&points, &target)
+            }
         }
     }
 }
@@ -175,9 +204,9 @@ pub struct NDInterpolation<'a> {
 
 impl<'a> NDInterpolation<'a> {
     pub fn new(strategy: &'a InterpolationStrategyEnum) -> Self {
-        NDInterpolation { 
-            points: HashMap::new(), 
-            strategy 
+        NDInterpolation {
+            points: HashMap::new(),
+            strategy,
         }
     }
 
@@ -197,14 +226,18 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
     const TOLERANCE: f64 = 1e-5;
-    
+
     fn approx_eq(left: &[f64], right: &[f64], tolerance: f64) -> bool {
-        left.len() == right.len() && 
-        left.iter().zip(right.iter()).all(|(a, b)| (a - b).abs() <= tolerance)
+        left.len() == right.len()
+            && left
+                .iter()
+                .zip(right.iter())
+                .all(|(a, b)| (a - b).abs() <= tolerance)
     }
 
     fn setup_linear_interpolator() -> NDInterpolation<'static> {
-        static LINEAR_STRATEGY: InterpolationStrategyEnum = InterpolationStrategyEnum::Linear(Linear);
+        static LINEAR_STRATEGY: InterpolationStrategyEnum =
+            InterpolationStrategyEnum::Linear(Linear);
         NDInterpolation::new(&LINEAR_STRATEGY)
     }
 
@@ -214,11 +247,41 @@ mod tests {
         let mut interpolator = NDInterpolation::new(&strategy);
 
         // Add sample points
-        interpolator.add_point(Point { coordinates: vec![1.0], file:None }, 2.0);
-        interpolator.add_point(Point { coordinates: vec![2.0], file:None }, 4.0);
-        interpolator.add_point(Point { coordinates: vec![3.0], file:None }, 6.0);
-        interpolator.add_point(Point { coordinates: vec![4.0], file:None }, 8.0);
-        interpolator.add_point(Point { coordinates: vec![5.0], file:None }, 10.0);
+        interpolator.add_point(
+            Point {
+                coordinates: vec![1.0],
+                file: None,
+            },
+            2.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![2.0],
+                file: None,
+            },
+            4.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![3.0],
+                file: None,
+            },
+            6.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![4.0],
+                file: None,
+            },
+            8.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![5.0],
+                file: None,
+            },
+            10.0,
+        );
 
         let target = vec![vec![6.0]];
         let interpolated_values = interpolator.interpolate(&target).unwrap();
@@ -227,7 +290,8 @@ mod tests {
         if !success {
             let message = format!(
                 "The extrapolated value was {:?}, but {:?} was expected",
-                interpolated_values, vec![12.0]
+                interpolated_values,
+                vec![12.0]
             );
             panic!("{}", message);
         }
@@ -236,8 +300,20 @@ mod tests {
     #[test]
     fn test_basic_linear_interpolation() {
         let mut interpolator = setup_linear_interpolator();
-        interpolator.add_point(Point { coordinates: vec![1.0], file: None }, 1.0);
-        interpolator.add_point(Point { coordinates: vec![3.0], file: None }, 3.0);
+        interpolator.add_point(
+            Point {
+                coordinates: vec![1.0],
+                file: None,
+            },
+            1.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![3.0],
+                file: None,
+            },
+            3.0,
+        );
 
         let target = vec![vec![2.0]];
         let interpolated_values = interpolator.interpolate(&target).unwrap();
@@ -248,8 +324,20 @@ mod tests {
     #[test]
     fn test_edge_case_interpolation() {
         let mut interpolator = setup_linear_interpolator();
-        interpolator.add_point(Point { coordinates: vec![0.0], file: None }, 0.0);
-        interpolator.add_point(Point { coordinates: vec![10.0], file: None }, 20.0);
+        interpolator.add_point(
+            Point {
+                coordinates: vec![0.0],
+                file: None,
+            },
+            0.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![10.0],
+                file: None,
+            },
+            20.0,
+        );
 
         let targets = vec![vec![0.0], vec![10.0]];
         let interpolated_values = interpolator.interpolate(&targets).unwrap();
@@ -262,8 +350,20 @@ mod tests {
     fn test_multiple_dimension_interpolation() {
         // Assuming NDInterpolation supports multi-dimensional points
         let mut interpolator = setup_linear_interpolator();
-        interpolator.add_point(Point { coordinates: vec![0.0, 0.0], file: None }, 0.0);
-        interpolator.add_point(Point { coordinates: vec![1.0, 1.0], file: None }, 2.0);
+        interpolator.add_point(
+            Point {
+                coordinates: vec![0.0, 0.0],
+                file: None,
+            },
+            0.0,
+        );
+        interpolator.add_point(
+            Point {
+                coordinates: vec![1.0, 1.0],
+                file: None,
+            },
+            2.0,
+        );
 
         let target = vec![vec![0.5, 0.5]];
         let interpolated_values = interpolator.interpolate(&target).unwrap();
@@ -275,12 +375,21 @@ mod tests {
     #[test]
     fn test_insufficient_points() {
         let mut interpolator = setup_linear_interpolator();
-        interpolator.add_point(Point { coordinates: vec![1.0], file: None }, 1.0);
+        interpolator.add_point(
+            Point {
+                coordinates: vec![1.0],
+                file: None,
+            },
+            1.0,
+        );
 
         let target = vec![vec![2.0]];
         let result = interpolator.interpolate(&target);
 
-        assert!(result.is_err(), "Interpolation should fail with insufficient points.");
+        assert!(
+            result.is_err(),
+            "Interpolation should fail with insufficient points."
+        );
     }
 
     #[test]
@@ -293,15 +402,25 @@ mod tests {
         for i in 0..DATASET_SIZE_IN {
             let x = i as f64;
             let y = 2.0 * x; // Simple linear relationship for the sake of example
-            interpolator.add_point(Point { coordinates: vec![x], file: None }, y);
+            interpolator.add_point(
+                Point {
+                    coordinates: vec![x],
+                    file: None,
+                },
+                y,
+            );
         }
 
         // Define a target vector for interpolation across a range of values
-        let target: Vec<Vec<f64>> = (0..DATASET_SIZE_TARGET).map(|i| vec![i as f64 + 0.5]).collect();
+        let target: Vec<Vec<f64>> = (0..DATASET_SIZE_TARGET)
+            .map(|i| vec![i as f64 + 0.5])
+            .collect();
 
         // Measure the time it takes to interpolate the entire dataset
         let start_time = Instant::now();
-        let _ = interpolator.interpolate(&target).expect("Interpolation failed");
+        let _ = interpolator
+            .interpolate(&target)
+            .expect("Interpolation failed");
         let duration = start_time.elapsed();
 
         // Log the time taken to stdout (consider using logging frameworks for real applications)
@@ -310,7 +429,9 @@ mod tests {
         // Example of asserting on performance (not recommended for CI/CD)
         // Assert that the operation completes within a specified duration (e.g., 2 seconds)
         // This is highly hardware and load dependent and should be used with caution
-        assert!(duration < Duration::from_secs(2), "Interpolation took too long");
+        assert!(
+            duration < Duration::from_secs(2),
+            "Interpolation took too long"
+        );
     }
-
 }

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -188,9 +188,9 @@ impl InterpolationStrategyEnum {
         target: &Vec<Vec<f64>>,
     ) -> Result<Vec<f64>, String> {
         match self {
-            InterpolationStrategyEnum::Linear(strategy) => strategy.interpolate(&points, &target),
+            InterpolationStrategyEnum::Linear(strategy) => strategy.interpolate(points, target),
             InterpolationStrategyEnum::NearestNeighbor(strategy) => {
-                strategy.interpolate(&points, &target)
+                strategy.interpolate(points, target)
             }
         }
     }
@@ -217,7 +217,7 @@ impl<'a> NDInterpolation<'a> {
 
     // Delegates to the strategy's interpolate method
     pub fn interpolate(&self, target: &Vec<Vec<f64>>) -> Result<Vec<f64>, String> {
-        self.strategy.interpolate(&self.points, &target)
+        self.strategy.interpolate(&self.points, target)
     }
 }
 
@@ -286,7 +286,7 @@ mod tests {
         let target = vec![vec![6.0]];
         let interpolated_values = interpolator.interpolate(&target).unwrap();
 
-        let success = approx_eq(&interpolated_values, &vec![12.0], TOLERANCE);
+        let success = approx_eq(&interpolated_values, &[12.0], TOLERANCE);
         if !success {
             let message = format!(
                 "The extrapolated value was {:?}, but {:?} was expected",

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -50,7 +50,7 @@ pub trait InterpolationStrategy {
     fn interpolate(
         &self,
         points: &HashMap<Point, f64>,
-        target: &Vec<Vec<f64>>,
+        target: &[Vec<f64>],
     ) -> Result<Vec<f64>, String>;
 }
 
@@ -61,7 +61,7 @@ impl InterpolationStrategy for NearestNeighbor {
     fn interpolate(
         &self,
         points: &HashMap<Point, f64>,
-        target: &Vec<Vec<f64>>,
+        target: &[Vec<f64>],
     ) -> Result<Vec<f64>, String> {
         if points.is_empty() {
             return Err("No points available for interpolation.".to_string());
@@ -102,7 +102,7 @@ impl InterpolationStrategy for Linear {
     fn interpolate(
         &self,
         points: &HashMap<Point, f64>,
-        target: &Vec<Vec<f64>>,
+        target: &[Vec<f64>],
     ) -> Result<Vec<f64>, String> {
         if points.len() < 2 {
             return Err("Not enough points for interpolation".to_string());
@@ -185,7 +185,7 @@ impl InterpolationStrategyEnum {
     pub fn interpolate(
         &self,
         points: &HashMap<Point, f64>,
-        target: &Vec<Vec<f64>>,
+        target: &[Vec<f64>],
     ) -> Result<Vec<f64>, String> {
         match self {
             InterpolationStrategyEnum::Linear(strategy) => strategy.interpolate(points, target),
@@ -216,7 +216,7 @@ impl<'a> NDInterpolation<'a> {
     }
 
     // Delegates to the strategy's interpolate method
-    pub fn interpolate(&self, target: &Vec<Vec<f64>>) -> Result<Vec<f64>, String> {
+    pub fn interpolate(&self, target: &[Vec<f64>]) -> Result<Vec<f64>, String> {
         self.strategy.interpolate(&self.points, target)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ pub mod interpolate;
 pub mod rainflow;
 pub use interpolate::{InterpolationStrategy, Linear, NDInterpolation};
 #[cfg(feature = "cli")]
-mod app_logic;
-#[cfg(feature = "cli")]
 pub mod config;
 #[cfg(feature = "cli")]
 pub mod material;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
 #[cfg(any(feature = "cli", feature = "wasm"))]
-pub mod rainflow;
-#[cfg(any(feature = "cli", feature = "wasm"))]
 pub mod interpolate;
+#[cfg(any(feature = "cli", feature = "wasm"))]
+pub mod rainflow;
 pub use interpolate::{InterpolationStrategy, Linear, NDInterpolation};
 #[cfg(feature = "cli")]
 mod app_logic;
 #[cfg(feature = "cli")]
 pub mod config;
 #[cfg(feature = "cli")]
-pub mod stress;
-#[cfg(feature = "cli")]
 pub mod material;
+#[cfg(feature = "cli")]
+pub mod stress;
 #[cfg(feature = "cli")]
 pub mod timeseries;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub fn run_rainflow(stress: &[f64]) -> Vec<f64> {
     // Combine the means and ranges into a single Vec to return.
     // This is just one way to handle the return; you might choose a different method
     // depending on how you want to process the data on the JavaScript side.
-    means.into_iter().chain(ranges.into_iter()).collect()
+    means.into_iter().chain(ranges).collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 //! A module for the main application logic for the fatigue assessment tool
-#[cfg(any(feature = "cli", feature = "wasm"))]
-pub mod rainflow;
 #[cfg(feature = "cli")]
 mod app_logic;
 #[cfg(feature = "cli")]
 pub mod config;
-#[cfg(feature = "cli")]
-pub mod stress;
 #[cfg(any(feature = "cli", feature = "wasm"))]
 pub mod interpolate;
+#[cfg(any(feature = "cli", feature = "wasm"))]
+pub mod rainflow;
+#[cfg(feature = "cli")]
+pub mod stress;
 pub use interpolate::{InterpolationStrategy, Linear, NDInterpolation};
 
 #[cfg(feature = "cli")]
@@ -29,24 +29,26 @@ fn main() {
                 .short('r')
                 .long("run")
                 .required(false)
-                .help("Run the program with the specified configuration file")
+                .help("Run the program with the specified configuration file"),
         )
         .arg(
             Arg::new("mode")
                 .short('m')
                 .long("mode")
                 .required(false)
-                .help("Sets the execution mode: cloud or local")
+                .help("Sets the execution mode: cloud or local"),
         )
         .arg(
             Arg::new("rainflow")
                 .short('a')
                 .long("rainflow")
                 .required(false)
-                .help("Perform rainflow counting on the input data")
-        )        
-        .after_help("Longer explanation to appear after the options when \
-                     displaying the help information from --help or -h")
+                .help("Perform rainflow counting on the input data"),
+        )
+        .after_help(
+            "Longer explanation to appear after the options when \
+                     displaying the help information from --help or -h",
+        )
         .get_matches();
 
     // Match the commands and execute the appropriate functionality
@@ -59,4 +61,3 @@ fn main() {
 
     // Additional CLI logic would be here
 }
-

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,7 +1,7 @@
 //! A module for material properties for a structural fatigue analysis application.
 
+use anyhow::{anyhow, Result};
 use serde::Deserialize;
-use anyhow::{Result, anyhow};
 /// Represents material properties used in structural analysis.
 ///
 /// Includes material's mechanical properties such as Young's modulus, Poisson's ratio,
@@ -36,16 +36,28 @@ impl Material {
             return Err(anyhow!("name must not be empty, got {}", self.name));
         }
         if self.youngs_modulus < 0.0 {
-            return Err(anyhow!("youngs_modulus must be greater than 0.0, got {}", self.youngs_modulus));
+            return Err(anyhow!(
+                "youngs_modulus must be greater than 0.0, got {}",
+                self.youngs_modulus
+            ));
         }
         if self.poissons_ratio < 0.0 {
-            return Err(anyhow!("poissons_ratio must be greater than 0.0, got {}", self.poissons_ratio));
+            return Err(anyhow!(
+                "poissons_ratio must be greater than 0.0, got {}",
+                self.poissons_ratio
+            ));
         }
         if self.yield_stress < 0.0 {
-            return Err(anyhow!("yield_stress must be greater than 0.0, got {}", self.yield_stress));
+            return Err(anyhow!(
+                "yield_stress must be greater than 0.0, got {}",
+                self.yield_stress
+            ));
         }
         if self.ultimate_stress < 0.0 {
-            return Err(anyhow!("ultimate_stress must be greater than 0.0, got {}", self.ultimate_stress));
+            return Err(anyhow!(
+                "ultimate_stress must be greater than 0.0, got {}",
+                self.ultimate_stress
+            ));
         }
         self.fatigue.validate()?;
         Ok(())
@@ -108,7 +120,7 @@ impl Slope {
             return Err(anyhow!("m2 must be greater than 0, got {}", self.m2));
         }
         Ok(())
-    }    
+    }
 }
 
 /// Represents the knee point of the S-N curve for fatigue analysis.
@@ -134,7 +146,10 @@ impl Knee {
             return Err(anyhow!("cycle must be greater than 0, got {}", self.cycle));
         }
         if self.stress < 0.0 {
-            return Err(anyhow!("stress must be greater than 0.0, got {}", self.stress));
+            return Err(anyhow!(
+                "stress must be greater than 0.0, got {}",
+                self.stress
+            ));
         }
         Ok(())
     }

--- a/src/rainflow.rs
+++ b/src/rainflow.rs
@@ -73,10 +73,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_rainflow(){
-        let stress_sequence = vec![-2.0, 1.0, -3.0, 5.0, -1.0, 3.0, -4.0, 4.0, -3.0, 1.0, -2.0, 3.0, 6.0];
+    fn test_rainflow() {
+        let stress_sequence = vec![
+            -2.0, 1.0, -3.0, 5.0, -1.0, 3.0, -4.0, 4.0, -3.0, 1.0, -2.0, 3.0, 6.0,
+        ];
         let (means, ranges) = rainflow(&stress_sequence);
-    
+
         // Output the results
         for (mean, range) in means.iter().zip(ranges.iter()) {
             println!("{:.4}, {:.4}", mean, range);

--- a/src/stress.rs
+++ b/src/stress.rs
@@ -82,7 +82,7 @@ impl StressTensor {
         let eigenvectors = eigen.eigenvectors;
         let x = eigenvectors.column(0).normalize();
         let mut z = eigenvectors.column(2).into_owned();
-        z = z / eigenvectors.column(2).norm();
+        z /= eigenvectors.column(2).norm();
         let y = x.cross(&z);
         let rot = Matrix3::from_columns(&[x, z, y]);
         rot.transpose()
@@ -195,11 +195,11 @@ mod tests {
         let matrix = Matrix3::new(1.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 3.0);
         let stress = StressTensor::new(matrix);
         let max_principal_stress = stress.max_principal_stress();
-        assert_relative_eq!(max_principal_stress, 4.2360679774997898, epsilon = 1e-6);
+        assert_relative_eq!(max_principal_stress, 4.236_067_977_499_79, epsilon = 1e-6);
         let von_mises_stress = stress.von_mises_stress();
         assert_relative_eq!(von_mises_stress, 4.358898943540674, epsilon = 1e-6);
         let matrix = Matrix3::new(
-            -17.863839999999999,
+            -17.863_84,
             1.54556,
             0.016324870000000002,
             1.54556,

--- a/src/stress.rs
+++ b/src/stress.rs
@@ -56,15 +56,6 @@ impl StressTensor {
         )
     }
 
-    /// Converts the internal Vector6 back to a Matrix3
-    /* fn vector_to_matrix(vector: &Vector6<f64>) -> Matrix3<f64> {
-        Matrix3::new(
-            vector[0], vector[3], vector[5], // Row 1: σxx, τxy, τzx
-            vector[3], vector[1], vector[4], // Row 2: τxy, σyy, τyz
-            vector[5], vector[4], vector[2], // Row 3: τzx, τyz, σzz
-        )
-    }*/
-
     // method to update the stress tensor
     pub fn update_stress(&mut self, matrix: Matrix3<f64>) {
         self.matrix = matrix;

--- a/src/stress.rs
+++ b/src/stress.rs
@@ -1,10 +1,9 @@
 //! A module for stress tensor operations
 extern crate nalgebra as na;
-use na::{Matrix3, SymmetricEigen, Vector6, Const};
+use na::{Const, Matrix3, SymmetricEigen, Vector6};
 use std::fs::File;
-use std::io::{BufReader, BufRead, Error};
+use std::io::{BufRead, BufReader, Error};
 use std::path::Path;
-
 
 /// A struct representing a stress tensor where the stress components are stored in a 3x3 matrix and a 6x1 vector
 #[derive(Debug)]
@@ -78,12 +77,12 @@ impl StressTensor {
     }
 
     // Calculate the principal direction of the maximum principal stress
-    pub fn principal_direction(&self) ->  Matrix3<f64> {
+    pub fn principal_direction(&self) -> Matrix3<f64> {
         let eigen = self.matrix.symmetric_eigen();
         let eigenvectors = eigen.eigenvectors;
         let x = eigenvectors.column(0).normalize();
         let mut z = eigenvectors.column(2).into_owned();
-        z = z/eigenvectors.column(2).norm();
+        z = z / eigenvectors.column(2).norm();
         let y = x.cross(&z);
         let rot = Matrix3::from_columns(&[x, z, y]);
         rot.transpose()
@@ -92,7 +91,12 @@ impl StressTensor {
     // Example method to get the maximum principal stress
     pub fn max_principal_stress(&self) -> f64 {
         let eigen = self.principal_stresses();
-        *eigen.eigenvalues.as_slice().iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap()
+        *eigen
+            .eigenvalues
+            .as_slice()
+            .iter()
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap()
     }
 
     pub fn von_mises_stress(&self) -> f64 {
@@ -106,7 +110,9 @@ impl StressTensor {
 
 // Function to read stress tensors from a file and return them as a vector of tuples
 // Each tuple contains a node number and a `StressTensor` instance
-pub fn read_stress_tensors_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<(usize, StressTensor)>, Error> {
+pub fn read_stress_tensors_from_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<(usize, StressTensor)>, Error> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let mut tensors = Vec::new();
@@ -115,17 +121,17 @@ pub fn read_stress_tensors_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<(usi
         let line = line?;
         // Update this based on your file's format
         let delimiter = ' '; // Assuming space or another character as delimiter
-        let values: Vec<f64> = line.split(delimiter)
-                                   .filter_map(|s| s.trim().parse::<f64>().ok())
-                                   .collect();
+        let values: Vec<f64> = line
+            .split(delimiter)
+            .filter_map(|s| s.trim().parse::<f64>().ok())
+            .collect();
 
         // Ensure there are enough values for a node number and a matrix
         if values.len() == 7 {
             let node_number = values[0] as usize;
             let matrix = Matrix3::new(
-                values[1], values[4], values[6],
-                values[4], values[2], values[5],
-                values[6], values[5], values[3],
+                values[1], values[4], values[6], values[4], values[2], values[5], values[6],
+                values[5], values[3],
             );
 
             let tensor = StressTensor::new(matrix); // Assuming this constructor exists
@@ -135,14 +141,13 @@ pub fn read_stress_tensors_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<(usi
     Ok(tensors)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use na::Vector3;
     use std::io;
-    
+
     #[test]
     fn test_update_stress() {
         let initial_matrix = Matrix3::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -177,33 +182,37 @@ mod tests {
         let stress_tensor = StressTensor::new(matrix);
         let von_mises = stress_tensor.von_mises_stress();
         // Ensure literals are typed as f64 to match the expected type in calculations
-        let expected_von_mises = (((1.0_f64 - 2.0_f64).powi(2) + (2.0_f64 - 3.0_f64).powi(2) + (3.0_f64 - 1.0_f64).powi(2)) / 2.0_f64).sqrt();
+        let expected_von_mises = (((1.0_f64 - 2.0_f64).powi(2)
+            + (2.0_f64 - 3.0_f64).powi(2)
+            + (3.0_f64 - 1.0_f64).powi(2))
+            / 2.0_f64)
+            .sqrt();
         assert_eq!(von_mises, expected_von_mises);
     }
-   
+
     #[test]
     fn test_stress_tensor() {
-        let matrix = Matrix3::new(
-            1.0, 0.0, 2.0,
-            0.0, 0.0, 0.0,
-            2.0, 0.0, 3.0,
-        );
-        let stress = StressTensor::new(matrix);        
+        let matrix = Matrix3::new(1.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 3.0);
+        let stress = StressTensor::new(matrix);
         let max_principal_stress = stress.max_principal_stress();
         assert_relative_eq!(max_principal_stress, 4.2360679774997898, epsilon = 1e-6);
         let von_mises_stress = stress.von_mises_stress();
         assert_relative_eq!(von_mises_stress, 4.358898943540674, epsilon = 1e-6);
         let matrix = Matrix3::new(
-            -17.863839999999999, 1.54556, 0.016324870000000002,
-            1.54556, -12.711300000000002, -0.013930999999999999,
-            0.016324870000000002, -0.013930999999999999, -14.825930000000001,
+            -17.863839999999999,
+            1.54556,
+            0.016324870000000002,
+            1.54556,
+            -12.711300000000002,
+            -0.013930999999999999,
+            0.016324870000000002,
+            -0.013930999999999999,
+            -14.825930000000001,
         );
-        let stress = StressTensor::new(matrix);            
+        let stress = StressTensor::new(matrix);
         let direction_calc = stress.principal_direction();
         let direction = Matrix3::new(
-            0.267,  0.964,   -0.004 ,
-            -0.006,  -0.002, -1.000,
-            -0.964, 0.267,  0.006,
+            0.267, 0.964, -0.004, -0.006, -0.002, -1.000, -0.964, 0.267, 0.006,
         );
         assert_relative_eq!(direction_calc, direction, epsilon = 1e-3);
     }
@@ -215,7 +224,7 @@ mod tests {
         // Initial vector check
         let expected_initial_vector = Vector6::new(1.0, 5.0, 9.0, 2.0, 6.0, 3.0);
         assert_eq!(stress_tensor.vector, expected_initial_vector);
-    
+
         // Update stress
         let updated_matrix = Matrix3::new(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         stress_tensor.update_stress(updated_matrix);
@@ -227,37 +236,35 @@ mod tests {
     #[test]
     fn test_read_stress_tensors_from_file() -> io::Result<()> {
         use crate::timeseries::ParseConfig;
-        use std::path::PathBuf;
-        use crate::timeseries::{Interpolation, Point}; // Ensure you import your Config and LoadCaseConfig
+        use crate::timeseries::{Interpolation, Point};
+        use std::path::PathBuf; // Ensure you import your Config and LoadCaseConfig
 
         // Assuming LoadCaseConfig is structured something like this
         let interp = Interpolation {
-            method: "LINEAR".to_string(), // Assuming interpolation method
+            method: "LINEAR".to_string(),         // Assuming interpolation method
             name: "StressTimeseries".to_string(), // Name of the time series
             path: "tests/stressfile".to_string(), // Base path to your test files
-            scale: 1.0, // Scale factor
-            dimension: 3, // Dimension for interpolation
+            scale: 1.0,                           // Scale factor
+            dimension: 3,                         // Dimension for interpolation
             sensor: vec!["FX".into(), "FY".into(), "FZ".into()], // Sensors for interpolation
-            points: vec![
-                Point {
-                    file: Some("Fx.usf".to_string()), // File for interpolation point
-                    coordinates: vec![0.0, 0.0, 0.0], // Assuming no specific value is provided; adjust if necessary
-                },
-            ],
+            points: vec![Point {
+                file: Some("Fx.usf".to_string()), // File for interpolation point
+                coordinates: vec![0.0, 0.0, 0.0], // Assuming no specific value is provided; adjust if necessary
+            }],
             parse_config: ParseConfig {
-                header: 1, // Assuming the first line is a header
+                header: 1,             // Assuming the first line is a header
                 delimiter: " ".into(), // Assuming space-delimited values
             },
         };
-        
+
         for point in &interp.points {
             // Check if `point.file` is `Some` and then construct the path
             if let Some(ref file_name) = point.file {
                 let path = PathBuf::from(&interp.path).join(file_name); // Correctly constructs the path
                 let tensors = read_stress_tensors_from_file(&path)?; // Assuming the function accepts a `&Path`
-                        // Assert that tensors are read correctly
-                // The exact assertions will depend on the expected content of your test file
-                // For example, if you know the specific tensors that should be parsed, assert those
+                                                                     // Assert that tensors are read correctly
+                                                                     // The exact assertions will depend on the expected content of your test file
+                                                                     // For example, if you know the specific tensors that should be parsed, assert those
                 assert!(!tensors.is_empty(), "Tensors should not be empty");
                 // Example assertion: check for a specific tensor value or node number
                 // assert_eq!(tensors[0].0, expected_node_number);
@@ -265,7 +272,7 @@ mod tests {
                 // Do something with `tensors` here
             }
         }
-        
+
         Ok(())
-    }    
+    }
 }

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -1,17 +1,17 @@
 //! Contains the `TimeSeries` struct and related functionality for time series analysis.
-use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
-use regex::Regex;
-use serde_json::from_str;
-use std::path::Path;
-use std::fs::{File, read_to_string};
-use std::io::BufReader;
-use evalexpr::{eval_with_context, ContextWithMutableVariables, HashMapContext, Value};
-use std::path::PathBuf;
-use crate::interpolate::{NDInterpolation, InterpolationStrategyEnum, Linear, NearestNeighbor};
 pub use crate::interpolate::Point;
+use crate::interpolate::{InterpolationStrategyEnum, Linear, NDInterpolation, NearestNeighbor};
 use crate::stress::read_stress_tensors_from_file;
-use anyhow::{Result, anyhow, Error};
+use anyhow::{anyhow, Error, Result};
+use evalexpr::{eval_with_context, ContextWithMutableVariables, HashMapContext, Value};
+use regex::Regex;
+use serde::Deserialize;
+use serde_json::from_str;
+use std::collections::{HashMap, HashSet};
+use std::fs::{read_to_string, File};
+use std::io::BufReader;
+use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct TimeSeries {
@@ -39,18 +39,26 @@ impl LoadCase {
             return Err(anyhow!("file must not be empty"));
         }
         if self.frequency < 0.0 {
-            return Err(anyhow!("frequency must be greater than 0.0, got {}", self.frequency));
+            return Err(anyhow!(
+                "frequency must be greater than 0.0, got {}",
+                self.frequency
+            ));
         }
         if self.gf_ext < 0.0 {
-            return Err(anyhow!("gf_ext must be greater than 0.0, got {}", self.gf_ext));
+            return Err(anyhow!(
+                "gf_ext must be greater than 0.0, got {}",
+                self.gf_ext
+            ));
         }
         if self.gf_fat < 0.0 {
-            return Err(anyhow!("gf_fat must be greater than 0.0, got {}", self.gf_fat));
+            return Err(anyhow!(
+                "gf_fat must be greater than 0.0, got {}",
+                self.gf_fat
+            ));
         }
         Ok(())
     }
 }
-
 
 #[derive(Debug, Deserialize)]
 pub struct ParseConfig {
@@ -86,7 +94,10 @@ impl Interpolation {
         self.parse_config.validate()?;
         match self.method.as_str() {
             "LINEAR" | "NEAREST" | "NONE" => Ok(()),
-            _ => Err(anyhow!("method must be LINEAR, NEAREST, or NONE, got {}", self.method)),
+            _ => Err(anyhow!(
+                "method must be LINEAR, NEAREST, or NONE, got {}",
+                self.method
+            )),
         }?;
         if self.name.trim().is_empty() {
             return Err(anyhow!("name must not be empty"));
@@ -96,7 +107,10 @@ impl Interpolation {
             return Err(anyhow!("path must not be empty"));
         }
         if self.scale < 0.0 {
-            return Err(anyhow!("scale must be greater than 0.0, got {}", self.scale));
+            return Err(anyhow!(
+                "scale must be greater than 0.0, got {}",
+                self.scale
+            ));
         }
         // Validate the dimension and sensor vector length condition
         if self.sensor.len() != self.dimension {
@@ -153,7 +167,7 @@ impl TimeSeries {
         self.validate_variables_and_values()?;
         if !Path::new(&self.sensorfile).exists() {
             return Err(anyhow!("sensorfile does not exist"));
-        }        
+        }
         if self.path.trim().is_empty() {
             return Err(anyhow!("path must not be empty"));
         }
@@ -173,10 +187,10 @@ impl TimeSeries {
             // Construct the full path for the loadcase file
             lc.validate()?;
             let full_path = format!("{}/{}", self.path.trim(), lc.file.trim());
-            
+
             if !Path::new(&full_path).exists() {
                 return Err(anyhow!("loadcase file does not exist: {}", full_path));
-            }            
+            }
         }
         Ok(())
     }
@@ -188,8 +202,8 @@ impl TimeSeries {
     /// Otherwise, returns an error detailing the issue encountered during file reading or deserialization.
 
     pub fn read_sensorfile(&self) -> Result<Vec<SensorFile>, Box<dyn std::error::Error>> {
-        // Reads the sensor file, deserializes its content into `SensorFile` structs, 
-        // and returns them for further processing.        
+        // Reads the sensor file, deserializes its content into `SensorFile` structs,
+        // and returns them for further processing.
         let content = read_to_string(&self.sensorfile)?;
         let sensors: Vec<SensorFile> = match from_str(&content) {
             Ok(sensors) => sensors,
@@ -232,11 +246,17 @@ impl TimeSeries {
         let mut valid_names = HashSet::<String>::new();
         let re = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
         // Add parameters and variables to valid names
-        self.parameters.iter().for_each(|(key, _)| { valid_names.insert(key.clone()); });
-        self.variables.iter().for_each(|(key, _)| { valid_names.insert(key.clone()); });
+        self.parameters.iter().for_each(|(key, _)| {
+            valid_names.insert(key.clone());
+        });
+        self.variables.iter().for_each(|(key, _)| {
+            valid_names.insert(key.clone());
+        });
         for interp in self.interpolations.iter() {
             valid_names.insert(interp.name.clone());
-            interp.sensor.iter().for_each(|sensor| { valid_names.insert(sensor.clone()); });
+            interp.sensor.iter().for_each(|sensor| {
+                valid_names.insert(sensor.clone());
+            });
         }
         for (key, value) in &self.variables {
             if !re.is_match(key) {
@@ -257,84 +277,109 @@ impl TimeSeries {
         // Validate variables expressions
         for (name, expression) in &self.variables {
             if !self.expression_valid(expression, &valid_names) {
-                return Err(anyhow!("Invalid expression for variable '{}': {}", name, expression));
+                return Err(anyhow!(
+                    "Invalid expression for variable '{}': {}",
+                    name,
+                    expression
+                ));
             }
         }
         Ok(())
     }
 
-     pub fn parse_input(&self) -> Result<HashMap<String, Value>, Error> {
+    pub fn parse_input(&self) -> Result<HashMap<String, Value>, Error> {
         let mut context = HashMapContext::new();
-    
+
         // Insert parameters into context
         for (key, value) in &self.parameters {
             println!("key: {:#?}", key);
             println!("value: {:#?}", value);
             let evalexpr_value = Value::Float(*value); // Clone if value cannot be copied
-            if context.set_value(key.clone(), evalexpr_value.clone()).is_err() {
+            if context
+                .set_value(key.clone(), evalexpr_value.clone())
+                .is_err()
+            {
                 return Err(anyhow!("Failed to insert parameter '{}' into context", key));
             }
         }
-    
+
         // Insert variables into context with actual values
         for key in &self.expressions.order {
-            let expression = self.variables
-            .get(key)
-            .ok_or_else(|| anyhow!("Variable '{}' not found in config", key))?;
+            let expression = self
+                .variables
+                .get(key)
+                .ok_or_else(|| anyhow!("Variable '{}' not found in config", key))?;
             match eval_with_context(expression, &context) {
                 Ok(result) => {
                     // Insert the result of the evaluation into the context
                     if context.set_value(key.to_string(), result.clone()).is_err() {
-                        return Err(anyhow!("Failed to insert result for variable '{}' into context", key));
+                        return Err(anyhow!(
+                            "Failed to insert result for variable '{}' into context",
+                            key
+                        ));
                     }
-                },
-                Err(e) => return Err(anyhow!("Failed to evaluate expression for variable '{}': {}", key, e)),
+                }
+                Err(e) => {
+                    return Err(anyhow!(
+                        "Failed to evaluate expression for variable '{}': {}",
+                        key,
+                        e
+                    ))
+                }
             }
         }
-    
+
         let mut results = HashMap::new();
         // Evaluate expressions based on the specified order
         for key in &self.expressions.order {
             if let Some(expression) = self.variables.get(key).map(|vars| vars) {
                 match eval_with_context(expression, &context) {
-                    Ok(result) => {   
+                    Ok(result) => {
                         // Also insert the result into the results hashmap
                         results.insert(key.clone(), result);
-                    },
+                    }
                     Err(e) => {
-                        return Err(anyhow!("Failed to evaluate expression '{}' for key '{}': {}", expression, key, e));
+                        return Err(anyhow!(
+                            "Failed to evaluate expression '{}' for key '{}': {}",
+                            expression,
+                            key,
+                            e
+                        ));
                     }
                 }
             }
         }
-    
+
         Ok(results)
     }
 
-    fn interpolate(&self, /* interpolation parameters */) -> Result<(), String> {
+    fn interpolate(&self /* interpolation parameters */) -> Result<(), String> {
         for interp in self.interpolations.iter() {
             // Revised strategy instantiation using the enum
             let strategy = match interp.method.as_str() {
-                "LINEAR" => InterpolationStrategyEnum::Linear(Linear{}),
-                "NEAREST" => InterpolationStrategyEnum::NearestNeighbor(NearestNeighbor{}),
+                "LINEAR" => InterpolationStrategyEnum::Linear(Linear {}),
+                "NEAREST" => InterpolationStrategyEnum::NearestNeighbor(NearestNeighbor {}),
                 _ => return Err("Unsupported interpolation method".to_string()),
             };
 
             // Initialize NDInterpolation with the chosen strategy
-            let mut interpolator_map: HashMap<usize, HashMap<String, NDInterpolation>> = HashMap::new();
+            let mut interpolator_map: HashMap<usize, HashMap<String, NDInterpolation>> =
+                HashMap::new();
             if let Some(ref file_name) = interp.points[0].file {
                 let path = PathBuf::from(&interp.path).join(file_name);
                 let tensors = read_stress_tensors_from_file(&path).unwrap(); // Handle the Result using `?`
                 for tensor in tensors.iter() {
                     // Retrieve or create the inner HashMap for the current tensor (node)
-                    let node_map = interpolator_map.entry(tensor.0).or_insert_with(HashMap::new);
+                    let node_map = interpolator_map
+                        .entry(tensor.0)
+                        .or_insert_with(HashMap::new);
                     // Insert NDInterpolation instances for SXX, SYY, and SZZ
                     node_map.insert("SXX".to_string(), NDInterpolation::new(&strategy));
                     node_map.insert("SYY".to_string(), NDInterpolation::new(&strategy));
                     node_map.insert("SZZ".to_string(), NDInterpolation::new(&strategy));
-                    node_map.insert("SXY".to_string(), NDInterpolation::new(&strategy));         
-                    node_map.insert("SYZ".to_string(), NDInterpolation::new(&strategy));         
-                    node_map.insert("SZX".to_string(), NDInterpolation::new(&strategy));                                    
+                    node_map.insert("SXY".to_string(), NDInterpolation::new(&strategy));
+                    node_map.insert("SYZ".to_string(), NDInterpolation::new(&strategy));
+                    node_map.insert("SZX".to_string(), NDInterpolation::new(&strategy));
                 }
             }
             // Assuming interp.path does not change, move the PathBuf construction outside the first loop.
@@ -372,7 +417,7 @@ impl TimeSeries {
                 }
             }
 
-            for lc in self.loadcases.iter(){
+            for lc in self.loadcases.iter() {
                 let _sensor = self.read_sensorfile().unwrap();
                 let path = PathBuf::from(&self.path).join(&lc.file);
                 let file = File::open(path).unwrap();
@@ -381,7 +426,6 @@ impl TimeSeries {
         }
         Ok(())
     }
-
 }
 
 /// Represents the order in which expressions should be evaluated in a structural analysis context.
@@ -431,7 +475,6 @@ impl Expressions {
     }
 }
 
-
 #[derive(Debug, Deserialize)]
 pub struct SensorFile {
     pub no: usize,
@@ -441,7 +484,6 @@ pub struct SensorFile {
     pub description: String,
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::config::load_config; // Ensure this is correctly imported
@@ -450,7 +492,10 @@ mod tests {
     fn test_interpolate_timeseries() {
         let config_path = "tests/config.yaml";
         let config = load_config(config_path).expect("Failed to load config");
-        config.timeseries.interpolate().expect("Failed to interpolate timeseries");
+        config
+            .timeseries
+            .interpolate()
+            .expect("Failed to interpolate timeseries");
     }
 
     #[test]
@@ -460,19 +505,36 @@ mod tests {
 
         println!("config: {:#?}", config);
 
-        let results = config.timeseries.parse_input().expect("Failed to parse input");
+        let results = config
+            .timeseries
+            .parse_input()
+            .expect("Failed to parse input");
         println!("Results: {:#?}", results);
         // Example of improved error handling in test assertions
         let max_value_result = results.get("max_value").and_then(|v| v.as_float().ok());
-        assert!(max_value_result.is_some(), "max_value not found or not a float");
+        assert!(
+            max_value_result.is_some(),
+            "max_value not found or not a float"
+        );
         assert_eq!(max_value_result.unwrap(), 5.0, "max_value should be 5.0");
 
         let sin_of_a_result = results.get("sin_of_a").and_then(|v| v.as_float().ok());
-        assert!(sin_of_a_result.is_some(), "sin_of_a not found or not a float");
+        assert!(
+            sin_of_a_result.is_some(),
+            "sin_of_a not found or not a float"
+        );
         // Compare floating point numbers within a small range to account for float precision issues
-        assert!((sin_of_a_result.unwrap() - f64::sin(5.0)).abs() < 1e-6, "sin_of_a should match the sine of 5.0");
+        assert!(
+            (sin_of_a_result.unwrap() - f64::sin(5.0)).abs() < 1e-6,
+            "sin_of_a should match the sine of 5.0"
+        );
 
-        let final_expression = results.get("final_expression").and_then(|v| v.as_float().ok());
-        assert!((final_expression.unwrap() - 22.051083228736417).abs() < 1e-6, "Should match 22.0510832");
+        let final_expression = results
+            .get("final_expression")
+            .and_then(|v| v.as_float().ok());
+        assert!(
+            (final_expression.unwrap() - 22.051083228736417).abs() < 1e-6,
+            "Should match 22.0510832"
+        );
     }
 }

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -370,9 +370,7 @@ impl TimeSeries {
                 let tensors = read_stress_tensors_from_file(&path).unwrap(); // Handle the Result using `?`
                 for tensor in tensors.iter() {
                     // Retrieve or create the inner HashMap for the current tensor (node)
-                    let node_map = interpolator_map
-                        .entry(tensor.0)
-                        .or_insert_with(HashMap::new);
+                    let node_map = interpolator_map.entry(tensor.0).or_default();
                     // Insert NDInterpolation instances for SXX, SYY, and SZZ
                     node_map.insert("SXX".to_string(), NDInterpolation::new(&strategy));
                     node_map.insert("SYY".to_string(), NDInterpolation::new(&strategy));

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -1,17 +1,13 @@
 //! Contains the `TimeSeries` struct and related functionality for time series analysis.
 pub use crate::interpolate::Point;
-use crate::interpolate::{InterpolationStrategyEnum, Linear, NDInterpolation, NearestNeighbor};
-use crate::stress::read_stress_tensors_from_file;
 use anyhow::{anyhow, Error, Result};
 use evalexpr::{eval_with_context, ContextWithMutableVariables, HashMapContext, Value};
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::from_str;
 use std::collections::{HashMap, HashSet};
-use std::fs::{read_to_string, File};
-use std::io::BufReader;
+use std::fs::read_to_string;
 use std::path::Path;
-use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct TimeSeries {
@@ -157,7 +153,6 @@ impl TimeSeries {
     ///
     /// Returns `Ok(())` if all configurations and data are valid. Otherwise,
     /// returns a `ValidationError` detailing the specific issue encountered.
-
     pub fn validate(&self) -> Result<()> {
         // Validates the existence of the sensor file and the correctness of specified paths.
         // Also ensures that interpolations and load cases are properly defined.
@@ -200,7 +195,6 @@ impl TimeSeries {
     ///
     /// Returns a `Result` containing a vector of `SensorFile` structs if successful.
     /// Otherwise, returns an error detailing the issue encountered during file reading or deserialization.
-
     pub fn read_sensorfile(&self) -> Result<Vec<SensorFile>, Box<dyn std::error::Error>> {
         // Reads the sensor file, deserializes its content into `SensorFile` structs,
         // and returns them for further processing.
@@ -332,7 +326,7 @@ impl TimeSeries {
         let mut results = HashMap::new();
         // Evaluate expressions based on the specified order
         for key in &self.expressions.order {
-            if let Some(expression) = self.variables.get(key).map(|vars| vars) {
+            if let Some(expression) = self.variables.get(key) {
                 match eval_with_context(expression, &context) {
                     Ok(result) => {
                         // Also insert the result into the results hashmap
@@ -351,78 +345,6 @@ impl TimeSeries {
         }
 
         Ok(results)
-    }
-
-    fn interpolate(&self /* interpolation parameters */) -> Result<(), String> {
-        for interp in self.interpolations.iter() {
-            // Revised strategy instantiation using the enum
-            let strategy = match interp.method.as_str() {
-                "LINEAR" => InterpolationStrategyEnum::Linear(Linear {}),
-                "NEAREST" => InterpolationStrategyEnum::NearestNeighbor(NearestNeighbor {}),
-                _ => return Err("Unsupported interpolation method".to_string()),
-            };
-
-            // Initialize NDInterpolation with the chosen strategy
-            let mut interpolator_map: HashMap<usize, HashMap<String, NDInterpolation>> =
-                HashMap::new();
-            if let Some(ref file_name) = interp.points[0].file {
-                let path = PathBuf::from(&interp.path).join(file_name);
-                let tensors = read_stress_tensors_from_file(&path).unwrap(); // Handle the Result using `?`
-                for tensor in tensors.iter() {
-                    // Retrieve or create the inner HashMap for the current tensor (node)
-                    let node_map = interpolator_map.entry(tensor.0).or_default();
-                    // Insert NDInterpolation instances for SXX, SYY, and SZZ
-                    node_map.insert("SXX".to_string(), NDInterpolation::new(&strategy));
-                    node_map.insert("SYY".to_string(), NDInterpolation::new(&strategy));
-                    node_map.insert("SZZ".to_string(), NDInterpolation::new(&strategy));
-                    node_map.insert("SXY".to_string(), NDInterpolation::new(&strategy));
-                    node_map.insert("SYZ".to_string(), NDInterpolation::new(&strategy));
-                    node_map.insert("SZX".to_string(), NDInterpolation::new(&strategy));
-                }
-            }
-            // Assuming interp.path does not change, move the PathBuf construction outside the first loop.
-            let base_path = PathBuf::from(&interp.path);
-
-            for point in &interp.points {
-                if let Some(ref file_name) = point.file {
-                    let path = base_path.join(file_name);
-                    // Use `?` for error propagation instead of `unwrap()`
-                    let tensors = read_stress_tensors_from_file(&path).unwrap();
-
-                    for tensor in &tensors {
-                        // Static mapping of components to methods; consider defining this outside of your loop if applicable.
-                        let components_and_methods = [
-                            ("SXX", tensor.1.sxx()),
-                            ("SYY", tensor.1.syy()),
-                            ("SZZ", tensor.1.szz()),
-                            ("SXY", tensor.1.sxy()),
-                            ("SYZ", tensor.1.syz()),
-                            ("SZX", tensor.1.szx()),
-                        ];
-                        if let Some(inner_map) = interpolator_map.get_mut(&tensor.0) {
-                            for (component, value) in components_and_methods.iter() {
-                                if let Some(nd_interpolation) = inner_map.get_mut(*component) {
-                                    nd_interpolation.add_point(point.clone(), *value);
-                                } else {
-                                    // Handle missing stress component in map for current node, if necessary.
-                                }
-                            }
-                        } else {
-                            // Handle missing node in `interpolator_map` more gracefully or log error as needed.
-                            return Err(format!("Node {} not found in interpolator_map", tensor.0));
-                        }
-                    }
-                }
-            }
-
-            for lc in self.loadcases.iter() {
-                let _sensor = self.read_sensorfile().unwrap();
-                let path = PathBuf::from(&self.path).join(&lc.file);
-                let file = File::open(path).unwrap();
-                let _reader = BufReader::new(file);
-            }
-        }
-        Ok(())
     }
 }
 
@@ -485,16 +407,6 @@ pub struct SensorFile {
 #[cfg(test)]
 mod tests {
     use crate::config::load_config; // Ensure this is correctly imported
-
-    #[test]
-    fn test_interpolate_timeseries() {
-        let config_path = "tests/config.yaml";
-        let config = load_config(config_path).expect("Failed to load config");
-        config
-            .timeseries
-            .interpolate()
-            .expect("Failed to interpolate timeseries");
-    }
 
     #[test]
     fn test_parse_input() {


### PR DESCRIPTION
## Summary

After the agent-guide PR (#9), the three commands documented in `CLAUDE.md` as
the pre-commit gate (`cargo fmt --all -- --check`, `cargo clippy
--all-features --all-targets -- -D warnings`, `cargo test`) did not pass on a
fresh checkout — `fmt --check` reported diffs across most files and clippy
flagged 21 warnings. Any agent following the docs would hit failures
unrelated to its change. This PR fixes the baseline and then enforces it in
CI so it can't drift again.

## Changes

Four commits, each independently verifiable:

- **`style: cargo fmt --all`** — mechanical rustfmt pass across 10 files.
  No behavior change.
- **`style: cargo clippy --fix`** — auto-applied fixes: redundant
  `.into_iter()`, compound-assign (`z = z/norm` → `z /= norm`), excessive
  float precision, identity `.map(|v| v)`.
- **`refactor: remove dead code and fix remaining clippy warnings`**
  - Delete `TimeSeries::interpolate` (flagged dead in the audit) and the
    single test that only exercised it; drop the imports it owned
    (`PathBuf`, `BufReader`, `File`, `InterpolationStrategyEnum`,
    `NearestNeighbor`, `Linear`, `NDInterpolation`,
    `read_stress_tensors_from_file`).
  - Drop `mod app_logic;` from `lib.rs` — the binary declares it in
    `main.rs`; nothing in the lib crate referenced it, so rustc flagged
    `run` as dead.
  - Change the `InterpolationStrategy` trait (and all impls / the enum
    dispatch / `NDInterpolation::interpolate`) from
    `target: &Vec<Vec<f64>>` to `target: &[Vec<f64>]` per clippy
    `ptr_arg`. Callers pass `&target` which auto-derefs; no call-site
    changes needed.
  - Delete the commented-out `vector_to_matrix` block in `stress.rs` and
    its orphan `///` doc comment.
  - Fix doc-comment blank-line separators (`timeseries.rs`, `config.rs`)
    and list-paragraph separation in `Solution::validate`.
  - Remove the orphan meta-doc-comment block above `load_config`.
- **`ci: enforce cargo fmt --check and clippy -D warnings`** — add both
  steps to `.github/workflows/rust.yml` so the CLAUDE.md gate is enforced
  going forward.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor (no behavior change for live code paths)
- [ ] Documentation only
- [x] CI / tooling

No public API removed. The `InterpolationStrategy` trait signature change
(`&Vec<Vec<f64>>` → `&[Vec<f64>]`) is source-compatible at every call site
in the crate because `&Vec<T>` coerces to `&[T]`.

## Test plan

Locally verified on every commit:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo test` — 16 unit tests + 6 doc tests pass (one test removed: it
  only exercised the deleted dead method)
- `cargo build --no-default-features --features wasm` — succeeds

## Notes for reviewers

- **One test was deleted** (`test_interpolate_timeseries` in
  `timeseries.rs`) because its only subject was the dead `fn interpolate`
  method. The remaining `test_parse_input` in the same module still
  covers the live code path.
- **Test count drops 17 → 16** for the same reason.
- Pre-existing tech debt still outstanding (out of scope here, tracked in
  `CLAUDE.md`'s "Known tech debt" list): `.unwrap()` calls in `config.rs`
  and `timeseries.rs`, silent JSON parse swallow in `timeseries.rs`,
  `Regex::new` in a validation loop, `Result<_, String>` in
  `interpolate.rs`. Happy to do these in a follow-up.